### PR TITLE
Allow Viewing of Own Profile if Not isAdmin

### DIFF
--- a/code/ZkMemberUser.php
+++ b/code/ZkMemberUser.php
@@ -70,6 +70,9 @@ class ZkMemberUser extends DataExtension {
 	}
 
 	public function canView($member) {
+		if ($this->owner->ID == Member::currentUserID()) {
+			return true;
+		}
 		return $this->isAdmin($member);
 	}
 


### PR DESCRIPTION
As a Member that wants to edit their own profile, they must also be able to view their profile.